### PR TITLE
NTI-4079 Reference static MimeType as a single element, no longer array

### DIFF
--- a/src/video-resources/components/EditVideo.jsx
+++ b/src/video-resources/components/EditVideo.jsx
@@ -28,7 +28,7 @@ function createVideoJSON (media) {
 		media.getTitle()
 	]).then(([sources, title]) => {
 		return {
-			MimeType: Models.media.Video.MimeType[0],
+			MimeType: Models.media.Video.MimeType,
 			title,
 			sources
 		};


### PR DESCRIPTION
Change related to https://github.com/NextThought/nti.lib.interfaces/commit/af8bd1e5f04bbf0321c76b8a3630f9a887a3bae3