### PR TITLE
NTI-4057: Buffer Loading never ends on mobile

### DIFF
--- a/src/controls/Mask.jsx
+++ b/src/controls/Mask.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {Loading} from 'nti-web-commons';
 
 VideoControlsMask.propTypes = {
-	poster: PropTypes.string
+	poster: PropTypes.string,
+	buffering: PropTypes.bool,
+	interacted: PropTypes.bool
 };
-export default function VideoControlsMask ({poster}) {
+export default function VideoControlsMask ({poster, buffering, interacted }) {
 	const style = poster ? {backgroundImage: `url(${poster})`} : {backgroundColor: 'transparent'};
 
 	return (
 		<div className="video-controls-mask" style={style}>
-			<span className="play-button" />
+			{!interacted && (<span className="play-button" />)}
+			{buffering && interacted && (<span className="buffer"><Loading.Spinner white size="50px" /></span>)}
 		</div>
 	);
 }

--- a/src/controls/Overlay.js
+++ b/src/controls/Overlay.js
@@ -117,7 +117,7 @@ export default class VideoControlsOverlay extends React.Component {
 
 		return (
 			<div className={cls} {...listeners} >
-				{(!interacted || !canPlay) && (<Mask {...otherProps} />)}
+				{(!interacted || !canPlay) && (<Mask buffering={!canPlay} interacted={interacted} {...otherProps} />)}
 				<UpperControls className="overlay-upper-controls" videoState={videoState} {...otherProps} showing={showControls} isTouch={isTouch} />
 				<LowerControls className="overlay-lower-controls" videoState={videoState} {...otherProps} showing={showControls} isTouch={isTouch} />
 			</div>


### PR DESCRIPTION
HTML5 videos on mobile don't fire onCanPlay because the readyState never hits 3. We remove the buffer entirely and wait until  there is interaction with the video to do any loading.