### PR TITLE
NTI-4329: Show the controls when buffering if has been interacted

### DIFF
--- a/src/controls/Overlay.jsx
+++ b/src/controls/Overlay.jsx
@@ -128,7 +128,7 @@ export default class VideoControlsOverlay extends React.Component {
 		const showMask = !interacted || !canPlay || !hasSources || ended;
 
 		const cls = cx('video-controls-overlay', className, {
-			'show-controls': showControls || (!showMask && !interacted),
+			'show-controls': showControls && interacted,
 			'is-touch': isTouch,
 			'can-play': canPlay,
 			'native-controls': shouldUseNativeControls,


### PR DESCRIPTION
This will show the controls during buffering if the video has been interacted with. This way you can change the res or pause the video.